### PR TITLE
Additional indexes on id and tstmp columns

### DIFF
--- a/seqware-meta-db/1.1.0_to_1.1.1-gsi.sql
+++ b/seqware-meta-db/1.1.0_to_1.1.1-gsi.sql
@@ -35,3 +35,24 @@ ALTER TABLE public.ius ALTER COLUMN sample_id DROP NOT NULL;
 ALTER TABLE public.ius ALTER COLUMN lane_id DROP NOT NULL;
 ALTER TABLE public.ius ADD COLUMN lims_key_id integer;
 ALTER TABLE public.ius ADD CONSTRAINT ius__lims_key_fk FOREIGN KEY (lims_key_id) REFERENCES lims_key(lims_key_id);
+
+CREATE INDEX ON lane_attribute (lane_id);
+CREATE INDEX ON sample_attribute (sample_id);
+CREATE INDEX ON sample (experiment_id);
+CREATE INDEX ON ius_attribute (ius_id);
+CREATE INDEX ON ius (lims_key_id);
+CREATE INDEX ON processing_ius (ius_id);
+CREATE INDEX ON file_attribute (file_id);
+CREATE INDEX ON workflow_run(workflow_id);
+CREATE INDEX ON processing_ius(processing_id);
+CREATE INDEX ON processing (workflow_run_id);
+CREATE INDEX ON processing_attribute (processing_id);
+CREATE INDEX ON workflow_run_attribute (workflow_run_id);
+CREATE INDEX ON workflow_attribute (workflow_id);
+
+CREATE INDEX ON workflow (update_tstmp);
+CREATE INDEX ON workflow_run (update_tstmp);
+CREATE INDEX ON processing (update_tstmp);
+CREATE INDEX ON ius(update_tstmp);
+
+CREATE INDEX ON file (meta_type);

--- a/seqware-meta-db/src/main/resources/io/seqware/metadb/util/seqware_meta_db.sql
+++ b/seqware-meta-db/src/main/resources/io/seqware/metadb/util/seqware_meta_db.sql
@@ -3822,6 +3822,13 @@ CREATE INDEX experiment_id_sample ON sample USING btree (experiment_id);
 
 
 --
+-- Name: file_attribute_file_id_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX file_attribute_file_id_idx ON file_attribute USING btree (file_id);
+
+
+--
 -- Name: file_id_processing_files; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
 --
 
@@ -3833,6 +3840,13 @@ CREATE INDEX file_id_processing_files ON processing_files USING btree (file_id);
 --
 
 CREATE INDEX file_id_workflow_run_input_files ON workflow_run_input_files USING btree (file_id);
+
+
+--
+-- Name: file_meta_type_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX file_meta_type_idx ON file USING btree (meta_type);
 
 
 --
@@ -3857,10 +3871,38 @@ CREATE INDEX index_processing_relationship_parent_id ON processing_relationship 
 
 
 --
+-- Name: ius_attribute_ius_id_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX ius_attribute_ius_id_idx ON ius_attribute USING btree (ius_id);
+
+
+--
 -- Name: ius_id_ius_workflow_runs; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
 --
 
 CREATE INDEX ius_id_ius_workflow_runs ON ius_workflow_runs USING btree (ius_id);
+
+
+--
+-- Name: ius_lims_key_id_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX ius_lims_key_id_idx ON ius USING btree (lims_key_id);
+
+
+--
+-- Name: ius_update_tstmp_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX ius_update_tstmp_idx ON ius USING btree (update_tstmp);
+
+
+--
+-- Name: lane_attribute_lane_id_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX lane_attribute_lane_id_idx ON lane_attribute USING btree (lane_id);
 
 
 --
@@ -3871,10 +3913,59 @@ CREATE INDEX parent_sample_hierarchy ON sample_hierarchy USING btree (parent_id)
 
 
 --
+-- Name: processing_attribute_processing_id_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX processing_attribute_processing_id_idx ON processing_attribute USING btree (processing_id);
+
+
+--
 -- Name: processing_id_processing_files; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
 --
 
 CREATE INDEX processing_id_processing_files ON processing_files USING btree (processing_id);
+
+
+--
+-- Name: processing_ius_ius_id_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX processing_ius_ius_id_idx ON processing_ius USING btree (ius_id);
+
+
+--
+-- Name: processing_ius_processing_id_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX processing_ius_processing_id_idx ON processing_ius USING btree (processing_id);
+
+
+--
+-- Name: processing_update_tstmp_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX processing_update_tstmp_idx ON processing USING btree (update_tstmp);
+
+
+--
+-- Name: processing_workflow_run_id_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX processing_workflow_run_id_idx ON processing USING btree (workflow_run_id);
+
+
+--
+-- Name: sample_attribute_sample_id_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX sample_attribute_sample_id_idx ON sample_attribute USING btree (sample_id);
+
+
+--
+-- Name: sample_experiment_id_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX sample_experiment_id_idx ON sample USING btree (experiment_id);
 
 
 --
@@ -3934,6 +4025,20 @@ CREATE UNIQUE INDEX sw_accession_workflow_run ON workflow_run USING btree (sw_ac
 
 
 --
+-- Name: workflow_attribute_workflow_id_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX workflow_attribute_workflow_id_idx ON workflow_attribute USING btree (workflow_id);
+
+
+--
+-- Name: workflow_run_attribute_workflow_run_id_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX workflow_run_attribute_workflow_run_id_idx ON workflow_run_attribute USING btree (workflow_run_id);
+
+
+--
 -- Name: workflow_run_id_ius_workflow_runs; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
 --
 
@@ -3952,6 +4057,27 @@ CREATE INDEX workflow_run_id_workflow_run_input_files ON workflow_run_input_file
 --
 
 CREATE INDEX workflow_run_processing ON processing USING btree (workflow_run_id);
+
+
+--
+-- Name: workflow_run_update_tstmp_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX workflow_run_update_tstmp_idx ON workflow_run USING btree (update_tstmp);
+
+
+--
+-- Name: workflow_run_workflow_id_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX workflow_run_workflow_id_idx ON workflow_run USING btree (workflow_id);
+
+
+--
+-- Name: workflow_update_tstmp_idx; Type: INDEX; Schema: public; Owner: seqware; Tablespace: 
+--
+
+CREATE INDEX workflow_update_tstmp_idx ON workflow USING btree (update_tstmp);
 
 
 --


### PR DESCRIPTION
- Primarily for seqware-common analysis_provenance_all.sql
- LIMS attribute id indexes are for sample and lane provenance