### PR TITLE
Use studyTitle of file metadata

### DIFF
--- a/seqware-common/src/main/java/net/sourceforge/seqware/common/hibernate/FindAllTheFiles.java
+++ b/seqware-common/src/main/java/net/sourceforge/seqware/common/hibernate/FindAllTheFiles.java
@@ -162,8 +162,8 @@ public class FindAllTheFiles {
     public static final String INPUT_FILE_FILE_PATHS = Header.INPUT_FILE_PATHS.getTitle();
     public static final String INPUT_FILE_SWIDS = Header.INPUT_FILE_SWIDS.getTitle();
 
-    public static void print(Writer writer, ReturnValue ret, String studyName, boolean showStatus, FileMetadata fm) throws IOException {
-        print(writer, ret, studyName, showStatus, fm, false);
+    public static void print(Writer writer, ReturnValue ret, boolean showStatus, FileMetadata fm) throws IOException {
+        print(writer, ret, showStatus, fm, false);
     }
 
     /**
@@ -183,7 +183,7 @@ public class FindAllTheFiles {
      * @param fm
      *            a {@link net.sourceforge.seqware.common.module.FileMetadata} object.
      */
-    public static void print(Writer writer, ReturnValue ret, String studyName, boolean showStatus, FileMetadata fm, boolean reportInputFiles)
+    public static void print(Writer writer, ReturnValue ret, boolean showStatus, FileMetadata fm, boolean reportInputFiles)
             throws IOException {
         StringBuilder parentSampleTag = new StringBuilder();
         StringBuilder sampleTag = new StringBuilder();
@@ -217,7 +217,7 @@ public class FindAllTheFiles {
         }
         StringBuilder sb = new StringBuilder();
         sb.append(ret.getAttribute(PROCESSING_DATE)).append("\t");
-        sb.append(studyName).append("\t");
+        sb.append(ret.getAttribute(STUDY_TITLE)).append("\t");
         sb.append(ret.getAttribute(STUDY_SWA)).append("\t");
         sb.append(studyTag.toString()).append("\t");
         sb.append(ret.getAttribute(EXPERIMENT_NAME)).append("\t");

--- a/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/deciders/BasicDecider.java
+++ b/seqware-pipeline/src/main/java/net/sourceforge/seqware/pipeline/deciders/BasicDecider.java
@@ -685,10 +685,9 @@ public class BasicDecider extends Plugin implements DeciderInterface {
     }
 
     protected void printFileMetadata(ReturnValue file, FileMetadata fm) {
-        String studyName = (String) options.valueOf("study-name");
         try {
             StringWriter writer = new StringWriter();
-            FindAllTheFiles.print(writer, file, studyName, true, fm);
+            FindAllTheFiles.print(writer, file, true, fm);
             studyReporterOutput.add(writer.getBuffer().toString().trim());
         } catch (IOException ex) {
             Log.error("Error printing file metadata", ex);


### PR DESCRIPTION
- don't use the study title that was provided as an argument
- removing this code allows support for providing multiple "study-name"
arguments